### PR TITLE
Scan all controllers

### DIFF
--- a/src/Routing/Route/ScopedRoute.php
+++ b/src/Routing/Route/ScopedRoute.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 namespace CakeAttributes\Routing\Route;
-namespace CakeAttributes\Routing\Route;
 
 use Cake\Routing\Route\Route;
 
@@ -25,7 +24,7 @@ class ScopedRoute extends Route
      */
     public function getUri(): string
     {
-        return $this->scope . $this->route->template;
+        return rtrim($this->scope, '/') . '/' . ltrim($this->route->template, '/');
     }
 
     /**

--- a/src/Routing/Route/ScopedRoute.php
+++ b/src/Routing/Route/ScopedRoute.php
@@ -32,7 +32,7 @@ class ScopedRoute extends Route
      */
     public function getDefinition(): string
     {
-        return sprintf('%s | %s | %s', $this->getName(), $this->getUri(), implode(',', $this->defaults['_method']));
+        return sprintf('%s | %s | %s', $this->getName(), $this->getUri(), $this->getMethods());
     }
 
     /**
@@ -49,5 +49,13 @@ class ScopedRoute extends Route
     public function setScope(string $scope): void
     {
         $this->scope = $scope;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethods(): string
+    {
+        return implode(',', $this->defaults['_method']);
     }
 }

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -204,14 +204,14 @@ class RouteProvider
         $directory = new RecursiveDirectoryIterator($basePath);
         $iterator = new RecursiveIteratorIterator($directory);
         $regex = new RegexIterator($iterator, '/.*Controller\.php$/i', RecursiveRegexIterator::GET_MATCH);
-        
+
         foreach ($regex as $file) {
             // Get the relative path to create the FQCN then combine the namespace with the relative path
             $relativePath = str_replace($basePath, '', $file[0]);
             $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
 
             // Ensure no leading or trailing backslashes
-            $className = ltrim($className, '\\'); 
+            $className = ltrim($className, '\\');
             $controllers[] = rtrim($namespace, '\\') . '\\' . $className;
         }
 

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -193,23 +193,33 @@ class RouteProvider
      *
      * @param string $basePath
      * @param string $namespace
-
      * @return array
      */
     protected function listControllers(string $basePath, string $namespace): array
     {
         $controllers = [];
-        $folder = new Filesystem();
+        // // Find all files matching '*Controller.php' in the folder recursively
+        // $folder = new Filesystem();
+        // $controllerFiles = $folder->findRecursive($basePath, '.*Controller\.php');
 
-        // Find all files matching '*Controller.php' in the folder recursively
-        $controllerFiles = $folder->findRecursive($basePath, '.*Controller\.php');
+        // foreach ($controllerFiles as $file) {
+        //     // Get the relative path to create the FQCN
+        //     //   then combine the namespace with the relative path
+        //     $relativePath = str_replace($basePath, '', $file);
+        //     $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
+        //     $controllers[] = $namespace . $className;
+        // }
 
-        foreach ($controllerFiles as $file) {
+        // TODO: Updated code that doesn't use the Filesystem class (internal)
+        $directory = new RecursiveDirectoryIterator($basePath);
+        $iterator = new RecursiveIteratorIterator($directory);
+        $regex = new RegexIterator($iterator, '/.*Controller\.php$/i', RecursiveRegexIterator::GET_MATCH);
+        
+        foreach ($regex as $file) {
             // Get the relative path to create the FQCN
-            $relativePath = str_replace($basePath, '', $file);
+            //   then combine the namespace with the relative path
+            $relativePath = str_replace($basePath, '', $file[0]);
             $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
-
-            // Combine the namespace with the relative path
             $controllers[] = $namespace . $className;
         }
 

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -208,6 +208,7 @@ class RouteProvider
         foreach ($regex as $file) {
             // Get the relative path to create the FQCN then combine the namespace with the relative path
             $relativePath = str_replace($basePath, '', $file[0]);
+            /** @var string $className */
             $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
 
             // Ensure no leading or trailing backslashes

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -5,9 +5,11 @@ namespace CakeAttributes\Routing;
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Routing\Route\Route as CakeRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
+use Cake\Utility\Filesystem;
 use CakeAttributes\Routing\Route\ScopedRoute;
 
 /**
@@ -122,10 +124,29 @@ class RouteProvider
             return;
         }
 
-        $controllers = Configure::read('Routing.controllers');
-        if (!$controllers) {
-            return;
+        $controllers = Configure::read('Routing.controllers', []);
+        if (empty($controllers)) {
+            $appControllers = $this->listControllers(
+                APP . 'Controller',
+                'App\\Controller\\'
+            );
+
+            $pluginControllers = [];
+            foreach (Plugin::loaded() as $pluginName) {
+                $pluginPath = Plugin::path($pluginName) . 'src/Controller';
+                if (is_dir($pluginPath)) {
+                    $pluginNamespace = $pluginName . '\\Controller\\';
+                    $pluginControllers = array_merge(
+                        $pluginControllers,
+                        $this->listControllers($pluginPath, $pluginNamespace)
+                    );
+                }
+            }
+
+            $controllers = array_merge($appControllers, $pluginControllers);
         }
+
+        dd($controllers);
 
         $routes = collection($this->getRoutes($controllers));
         if ($routes->isEmpty()) {
@@ -165,5 +186,33 @@ class RouteProvider
         /** @var array<\CakeAttributes\Routing\Route\ScopedRoute> $toBeCachedRoutes */
         $this->routes = $toBeCachedRoutes;
         Cache::write($this->cacheKey, $toBeCachedRoutes, $this->cacheConfig);
+    }
+
+    /**
+     * Scans a given base path for controllers and returns a list of fully-qualified class names
+     *
+     * @param string $basePath
+     * @param string $namespace
+
+     * @return array
+     */
+    protected function listControllers(string $basePath, string $namespace): array
+    {
+        $controllers = [];
+        $folder = new Filesystem();
+
+        // Find all files matching '*Controller.php' in the folder recursively
+        $controllerFiles = $folder->findRecursive($basePath, '.*Controller\.php');
+
+        foreach ($controllerFiles as $file) {
+            // Get the relative path to create the FQCN
+            $relativePath = str_replace($basePath, '', $file);
+            $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
+
+            // Combine the namespace with the relative path
+            $controllers[] = $namespace . $className;
+        }
+
+        return $controllers;
     }
 }

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -125,15 +125,15 @@ class RouteProvider
         }
 
         $controllers = Configure::read('Routing.controllers', []);
-        if (empty($controllers)) {
+        if ($controllers === []) {
             $appControllers = $this->listControllers(
                 APP . 'Controller',
-                'App\\Controller\\'
+                Configure::read('App.namespace') . '\\Controller\\'
             );
 
             $pluginControllers = [];
             foreach (Plugin::loaded() as $pluginName) {
-                $pluginPath = Plugin::path($pluginName) . 'src/Controller';
+                $pluginPath = Plugin::classPath($pluginName) . 'Controller';
                 if (is_dir($pluginPath)) {
                     $pluginNamespace = $pluginName . '\\Controller\\';
                     $pluginControllers = array_merge(

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -11,6 +11,10 @@ use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\Utility\Filesystem;
 use CakeAttributes\Routing\Route\ScopedRoute;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use RecursiveRegexIterator;
 
 /**
  * Scans controllers and returns route configuration objects for adding to the route table.
@@ -116,9 +120,10 @@ class RouteProvider
      * Automatically registers identified routes based on reflected attributes
      *
      * @param \Cake\Routing\RouteBuilder $builder
+     * @param string $basePath Path to scan
      * @return void
      */
-    public function autoRegister(RouteBuilder $builder): void
+    public function autoRegister(RouteBuilder $builder, string $basePath = APP): void
     {
         if (Configure::read('Routing.autoRegister') === false) {
             return;
@@ -127,7 +132,7 @@ class RouteProvider
         $controllers = Configure::read('Routing.controllers', []);
         if ($controllers === []) {
             $appControllers = $this->listControllers(
-                APP . 'Controller',
+                $basePath . 'Controller',
                 Configure::read('App.namespace') . '\\Controller\\'
             );
 

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -151,8 +151,6 @@ class RouteProvider
             $controllers = array_merge($appControllers, $pluginControllers);
         }
 
-        dd($controllers);
-
         $routes = collection($this->getRoutes($controllers));
         if ($routes->isEmpty()) {
             return;
@@ -203,29 +201,18 @@ class RouteProvider
     protected function listControllers(string $basePath, string $namespace): array
     {
         $controllers = [];
-        // // Find all files matching '*Controller.php' in the folder recursively
-        // $folder = new Filesystem();
-        // $controllerFiles = $folder->findRecursive($basePath, '.*Controller\.php');
-
-        // foreach ($controllerFiles as $file) {
-        //     // Get the relative path to create the FQCN
-        //     //   then combine the namespace with the relative path
-        //     $relativePath = str_replace($basePath, '', $file);
-        //     $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
-        //     $controllers[] = $namespace . $className;
-        // }
-
-        // TODO: Updated code that doesn't use the Filesystem class (internal)
         $directory = new RecursiveDirectoryIterator($basePath);
         $iterator = new RecursiveIteratorIterator($directory);
         $regex = new RegexIterator($iterator, '/.*Controller\.php$/i', RecursiveRegexIterator::GET_MATCH);
         
         foreach ($regex as $file) {
-            // Get the relative path to create the FQCN
-            //   then combine the namespace with the relative path
+            // Get the relative path to create the FQCN then combine the namespace with the relative path
             $relativePath = str_replace($basePath, '', $file[0]);
             $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
-            $controllers[] = $namespace . $className;
+
+            // Ensure no leading or trailing backslashes
+            $className = ltrim($className, '\\'); 
+            $controllers[] = rtrim($namespace, '\\') . '\\' . $className;
         }
 
         return $controllers;

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -9,12 +9,11 @@ use Cake\Core\Plugin;
 use Cake\Routing\Route\Route as CakeRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
-use Cake\Utility\Filesystem;
 use CakeAttributes\Routing\Route\ScopedRoute;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use RegexIterator;
 use RecursiveRegexIterator;
+use RegexIterator;
 
 /**
  * Scans controllers and returns route configuration objects for adding to the route table.

--- a/tests/TestCase/Router/RouteProviderTest.php
+++ b/tests/TestCase/Router/RouteProviderTest.php
@@ -71,16 +71,16 @@ class RouteProviderTest extends TestCase
             ->toArray();
 
         $expected = [
-            'users:edit | //users/edit/:id | GET',
-            'users:edit | //users/edit/:id | GET',
-            'users:delete | //users/delete/:id | POST',
-            'users:delete | //users/delete/:id | POST',
-            'users:add | //users/add | POST',
-            'users:add | //users/add | POST',
-            'users:view | //users/:id | GET',
-            'users:view | //users/:id | GET',
-            'users:index | //users | GET',
-            'users:index | //users | GET',
+            'users:edit | /users/edit/:id | GET',
+            'users:edit | /users/edit/:id | GET',
+            'users:delete | /users/delete/:id | POST',
+            'users:delete | /users/delete/:id | POST',
+            'users:add | /users/add | POST',
+            'users:add | /users/add | POST',
+            'users:view | /users/:id | GET',
+            'users:view | /users/:id | GET',
+            'users:index | /users | GET',
+            'users:index | /users | GET',
         ];
 
         $this->assertEquals($expected, $routeDefinitions);

--- a/tests/TestCase/Router/RouteProviderTest.php
+++ b/tests/TestCase/Router/RouteProviderTest.php
@@ -6,6 +6,7 @@ namespace CakeAttributes\Test\TestCase\Router;
 use Cake\Core\Configure;
 use Cake\Routing\Route\Route as CakeRoute;
 use Cake\Routing\Router;
+use Cake\Core\TestSuite\ContainerStubTrait;
 use Cake\TestSuite\TestCase;
 use CakeAttributes\Routing\Route\ScopedRoute;
 use CakeAttributes\Routing\RouteProvider;
@@ -18,6 +19,8 @@ use TestApp\Controller\UsersController;
  */
 class RouteProviderTest extends TestCase
 {
+    use ContainerStubTrait;
+
     protected RouteProvider $provider;
     protected array $configuredRoutes;
 
@@ -26,6 +29,11 @@ class RouteProviderTest extends TestCase
         parent::setUp();
 
         $this->setAppNamespace();
+        $this->configApplication(
+            'TestApp\Application',
+            [PLUGIN_TESTS . 'test_app' . DS . 'config']
+        );
+
         $this->provider = new RouteProvider('route_provider_test');
         $this->provider->clearCache();
         $this->configuredRoutes = $this->getConfiguredRoutes();
@@ -56,7 +64,7 @@ class RouteProviderTest extends TestCase
         $this->assertEquals($firstRun, $secondRun);
     }
 
-    public function testAutoRegisterRegistersCriticalRoutes(): void
+    public function testAutoRegisterScansApplicationControllersForRoutes(): void
     {
         $routeDefinitions = collection($this->configuredRoutes)
             ->map(fn (ScopedRoute $route) => $route->getDefinition())
@@ -76,6 +84,11 @@ class RouteProviderTest extends TestCase
         ];
 
         $this->assertEquals($expected, $routeDefinitions);
+    }
+
+    public function testAutoRegisterScansPluginControllersForRoutes(): void
+    {
+
     }
 
     public function testAutoRegisterRegistersFallbackRoutesWhenAllowFallbacksIsTrue(): void

--- a/tests/TestCase/Router/RouteProviderTest.php
+++ b/tests/TestCase/Router/RouteProviderTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace CakeAttributes\Test\TestCase\Router;
 
 use Cake\Core\Configure;
+use Cake\Core\TestSuite\ContainerStubTrait;
 use Cake\Routing\Route\Route as CakeRoute;
 use Cake\Routing\Router;
-use Cake\Core\TestSuite\ContainerStubTrait;
 use Cake\TestSuite\TestCase;
 use CakeAttributes\Routing\Route\ScopedRoute;
 use CakeAttributes\Routing\RouteProvider;
@@ -88,7 +88,7 @@ class RouteProviderTest extends TestCase
 
     public function testAutoRegisterScansPluginControllersForRoutes(): void
     {
-
+        // TODO: Fill in this test
     }
 
     public function testAutoRegisterRegistersFallbackRoutesWhenAllowFallbacksIsTrue(): void

--- a/tests/TestCase/Router/RouteProviderTest.php
+++ b/tests/TestCase/Router/RouteProviderTest.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace CakeAttributes\Test\TestCase\Router;
 
+use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\TestSuite\ContainerStubTrait;
 use Cake\Routing\Route\Route as CakeRoute;
+use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use CakeAttributes\Routing\Route\ScopedRoute;
@@ -70,25 +72,38 @@ class RouteProviderTest extends TestCase
             ->map(fn (ScopedRoute $route) => $route->getDefinition())
             ->toArray();
 
-        $expected = [
-            'users:edit | /users/edit/:id | GET',
+        $expectedRoutes = [
             'users:edit | /users/edit/:id | GET',
             'users:delete | /users/delete/:id | POST',
-            'users:delete | /users/delete/:id | POST',
-            'users:add | /users/add | POST',
             'users:add | /users/add | POST',
             'users:view | /users/:id | GET',
-            'users:view | /users/:id | GET',
-            'users:index | /users | GET',
             'users:index | /users | GET',
         ];
 
-        $this->assertEquals($expected, $routeDefinitions);
+        foreach ($expectedRoutes as $route) {
+            $this->assertTrue( in_array($route, $routeDefinitions, true));
+        }
     }
 
     public function testAutoRegisterScansPluginControllersForRoutes(): void
     {
-        // TODO: Fill in this test
+        $this->printRoutes(Router::getRouteCollection());
+
+        $routeDefinitions = collection($this->configuredRoutes)
+            ->map(fn (ScopedRoute $route) => $route->getDefinition())
+            ->toArray();
+
+        $expectedRoutes = [
+            'cars:edit | /cars/edit/:id | GET',
+            'cars:delete | /cars/delete/:id | POST',
+            'cars:add | /cars/add | POST',
+            'cars:view | /cars/:id | GET',
+            'cars:index | /cars | GET',
+        ];
+
+        foreach ($expectedRoutes as $route) {
+            $this->assertTrue( in_array($route, $routeDefinitions, true));
+        }
     }
 
     public function testAutoRegisterRegistersFallbackRoutesWhenAllowFallbacksIsTrue(): void
@@ -123,10 +138,38 @@ class RouteProviderTest extends TestCase
     {
         // Reset the router to defaults to that previously-registered routes don't pollute the test
         Router::reload();
-        $this->loadPlugins(['CakeAttributes']);
+
+        $this->loadPlugins([
+            'CakeAttributes',
+            'TestAppPlugin' => ['path' => PLUGIN_TESTS . 'test_app/plugins/TestAppPlugin/'],
+        ]);
+
+        $this->printRoutes(Router::getRouteCollection());
+
         $builder = Router::createRouteBuilder('/');
         $this->provider->autoRegister($builder);
 
         return Router::getRouteCollection()->routes();
+    }
+
+    /**
+     * @param \Cake\Routing\RouteCollection|null $collection
+     * @return void
+     */
+    private function printRoutes(RouteCollection $collection = null): void
+    {
+        $io = new ConsoleIo();
+        $collection ??= Router::getRouteCollection();
+
+        $routeDefinitions = collection($collection->routes())
+            ->map(fn (ScopedRoute $route) => [
+                $route->getName(),
+                $route->getMethods(),
+                $route->getUri(),
+            ])
+            ->toArray();
+
+        array_unshift($routeDefinitions, ['Name', 'Method(s)', 'URI']);
+        $io->helper('table')->output($routeDefinitions);
     }
 }

--- a/tests/TestCase/Router/RouteScannerTest.php
+++ b/tests/TestCase/Router/RouteScannerTest.php
@@ -89,12 +89,8 @@ class RouteScannerTest extends TestCase
 
     public static function getControllers(): array
     {
-        $controllers = Configure::read('Routing.controllers');
-        $result = [];
-        foreach ($controllers as $controller) {
-            $result[] = [$controller];
-        }
-
-        return $result;
+        return [
+            [\TestApp\Controller\UsersController::class],
+        ];
     }
 }

--- a/tests/TestCase/Router/RouteScannerTest.php
+++ b/tests/TestCase/Router/RouteScannerTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace CakeAttributes\Test\TestCase\Router;
 
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use CakeAttributes\Attributes\Prefix;
 use CakeAttributes\Attributes\Scope;
 use CakeAttributes\Routing\RouteScanner;
 use ReflectionClass;
+use TestApp\Controller\UsersController;
 
 /**
  * Route Scanner Test
@@ -90,7 +90,7 @@ class RouteScannerTest extends TestCase
     public static function getControllers(): array
     {
         return [
-            [\TestApp\Controller\UsersController::class],
+            [UsersController::class],
         ];
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,9 +21,6 @@ unset($findRoot);
 chdir($root);
 require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
-Configure::write('Routing.controllers', [
-    UsersController::class,
-]);
 Configure::write('Routing.autoRegister', true);
 
 define('MYTMP', __DIR__ . DS . '..' . DS . 'tmp' . DS);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Core\Configure;
-use TestApp\Controller\UsersController;
 
 $findRoot = function ($root) {
     do {
@@ -16,6 +15,7 @@ $findRoot = function ($root) {
     } while ($root !== $lastRoot);
     throw new Exception('Cannot find the root of the application, unable to run tests');
 };
+
 $root = $findRoot(__FILE__);
 unset($findRoot);
 chdir($root);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,20 +19,28 @@ $findRoot = function ($root) {
 $root = $findRoot(__FILE__);
 unset($findRoot);
 chdir($root);
-require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
+require_once 'vendor/autoload.php';
+// require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
+
+define('ROOT', $root . DS . 'tests' . DS . 'test_app' . DS);
+define('CAKE', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'src' . DS);
+define('APP', ROOT . 'src' . DS);
+// define('CONFIG', APP);
+define('TMP', sys_get_temp_dir() . DS);
+define('CACHE', TMP . 'cache' . DS);
+
+Configure::write('debug', true);
 Configure::write('Routing.autoRegister', true);
-
-define('MYTMP', __DIR__ . DS . '..' . DS . 'tmp' . DS);
 
 Cache::setConfig([
     'default' => [
         'engine' => FileEngine::class,
-        'path' => MYTMP,
+        'path' => TMP,
     ],
     'cake_attributes' => [
         'engine' => FileEngine::class,
-        'path' => MYTMP,
+        'path' => TMP,
     ],
 ]);
 

--- a/tests/test_app/plugins/TestAppPlugin/src/Controller/CarsController.php
+++ b/tests/test_app/plugins/TestAppPlugin/src/Controller/CarsController.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+use CakeAttributes\Attributes\Methods\Get;
+use CakeAttributes\Attributes\Methods\Post;
+
+class CarsController extends Controller
+{
+    #[Get('/cars')]
+    public function index()
+    {
+    }
+
+    #[Get('/cars/:id')]
+    public function view(?int $id = null)
+    {
+    }
+
+//    #[Get('/cars/add')]
+    #[Post('/cars/add')]
+    public function add()
+    {
+    }
+
+    #[Get('/cars/edit/:id')]
+//    #[Post('/cars/edit/:id')]
+//    #[Patch('/cars/edit/:id')]
+//    #[Put('/cars/edit/:id')]
+    public function edit(?int $id = null)
+    {
+    }
+
+    #[Post('/cars/delete/:id')]
+//    #[Delete('/cars/delete/:id')]
+    public function delete(?int $id = null)
+    {
+    }
+}

--- a/tests/test_app/plugins/TestAppPlugin/src/Plugin.php
+++ b/tests/test_app/plugins/TestAppPlugin/src/Plugin.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace TestAppPlugin;
+
+use Cake\Core\BasePlugin;
+
+class Plugin extends BasePlugin
+{
+}

--- a/tests/test_app/src/Application.php
+++ b/tests/test_app/src/Application.php
@@ -12,8 +12,6 @@ class Application extends BaseApplication
 {
     public function bootstrap(): void
     {
-        $this->addPlugin('CakeAttributes');
-        $this->addPlugin('TestAppPlugin');
     }
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue

--- a/tests/test_app/src/Application.php
+++ b/tests/test_app/src/Application.php
@@ -13,6 +13,7 @@ class Application extends BaseApplication
     public function bootstrap(): void
     {
         $this->addPlugin('CakeAttributes');
+        $this->addPlugin('TestAppPlugin');
     }
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue


### PR DESCRIPTION
If `Routing.controllers` is not set, scan all application and plugin controllers for routes.